### PR TITLE
Fix sdvx.in database updater

### DIFF
--- a/CroBot/features/sdvxin/regex.py
+++ b/CroBot/features/sdvxin/regex.py
@@ -3,7 +3,7 @@
 # Contains all of the regex strings to allow the main scripts to be less cluttered
 #
 
-id_parse = r'/(\d+)sort.js'
+id_parse = r'/js/(\d{5})(sort)?\.js'
 jacket_data = r'(/\d+/jacket/\d+[eighv]....)'
 jacket_sort = r'(/\d+/jacket/\d+[ighmv]....)'
 link = r'sdvx\.in/\d+/(\d+)[naeighmv]'


### PR DESCRIPTION
make searching for sort in the id parser optional, specify the /js/ path and number of digits to reduce false positives. sdvx.in have started loading scripts under the following format:
`document.write("<script type=text/javascript src=/05/js/05010.js></script>");//消失(Hommarju Remix)` the old format is still used in del.js: `document.write("<script type=text/javascript src=/01/js/01117sort.js></script>");//線香花火`, so those are the only charts that are added before this change